### PR TITLE
Fix segfault when closing application

### DIFF
--- a/source/engine/engine.cpp
+++ b/source/engine/engine.cpp
@@ -1,5 +1,6 @@
-//
-// Created by dikkie on 1/26/23.
-//
-
 #include "engine.h"
+#include "gfx/shader_manager.h"
+
+void Engine::shutdown() {
+    gfx::ShaderManager::instance().cleanup();
+}

--- a/source/engine/engine.h
+++ b/source/engine/engine.h
@@ -18,6 +18,7 @@ public:
         return mAllocator;
     }
 
+    void shutdown();
 private:
     Engine() = default;
 

--- a/source/gfx/render_pipeline.cpp
+++ b/source/gfx/render_pipeline.cpp
@@ -72,6 +72,15 @@ namespace gfx {
         {
         }
 
+        ~RenderPipelineImpl() override {
+            ShaderManager::instance().cleanup();
+
+            bgfx::destroy(mTextureUniform);
+
+            bgfx::destroy(mIbh);
+            bgfx::destroy(mVbh);
+        }
+
         void initialize() override {
             PosTextVertex::init();
 
@@ -148,7 +157,6 @@ namespace gfx {
 
             bgfx::frame();
         }
-
     private:
         int mWidth;
         int mHeight;
@@ -157,8 +165,9 @@ namespace gfx {
         bgfx::IndexBufferHandle mIbh;
         bgfx::FrameBufferHandle mFbh;
 
-        std::unique_ptr<Texture2D> mTexture { nullptr };
         bgfx::UniformHandle mTextureUniform = BGFX_INVALID_HANDLE;
+
+        std::unique_ptr<Texture2D> mTexture { nullptr };
 
         Shader *mShader { nullptr };
     };

--- a/source/gfx/render_pipeline.cpp
+++ b/source/gfx/render_pipeline.cpp
@@ -73,8 +73,6 @@ namespace gfx {
         }
 
         ~RenderPipelineImpl() override {
-            ShaderManager::instance().cleanup();
-
             bgfx::destroy(mTextureUniform);
 
             bgfx::destroy(mIbh);

--- a/source/gfx/shader.cpp
+++ b/source/gfx/shader.cpp
@@ -2,10 +2,8 @@
 
 namespace gfx {
     Shader::~Shader() {
-        bgfx::destroy(mProgramHandle);
-        if (mDestroyShaders) {
-            bgfx::destroy(mVertexShaderHandle);
-            bgfx::destroy(mFragmentShaderHandle);
+        if (compiled()) {
+            bgfx::destroy(mProgramHandle);
         }
     }
 
@@ -24,7 +22,7 @@ namespace gfx {
             }
         }
 
-        mProgramHandle = bgfx::createProgram(mVertexShaderHandle, mFragmentShaderHandle, true);
+        mProgramHandle = bgfx::createProgram(mVertexShaderHandle, mFragmentShaderHandle, mDestroyShaders);
         mCompiled = true;
     }
 

--- a/source/gfx/shader.h
+++ b/source/gfx/shader.h
@@ -36,7 +36,7 @@ namespace gfx {
             return mProgramHandle;
         }
 
-        [[nodiscard]] constexpr ALWAYS_INLINE bool isCompiled() const {
+        [[nodiscard]] constexpr ALWAYS_INLINE bool compiled() const {
             return mCompiled;
         }
     private:

--- a/source/gfx/shader_manager.h
+++ b/source/gfx/shader_manager.h
@@ -15,6 +15,10 @@ namespace gfx {
 
         Shader* createShader(const Path &path);
         Shader* getShader(const Path &path);
+
+        void cleanup() {
+            mShaders.clear();
+        }
     private:
         ShaderManager() = default;
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -2,6 +2,7 @@
 
 #include "engine/window.h"
 #include "gfx/render_pipeline.h"
+#include "engine/engine.h"
 
 #include <iostream>
 
@@ -20,6 +21,8 @@ auto main() -> int {
 
         renderPipeline->render();
     }
+
+    Engine::instance().shutdown();
 
     return 0;
 }


### PR DESCRIPTION
Fixed the error by cleaning up bgfx resources at the end of the application cycle in the engine. Doing it while static resources are being destructed caused issues in this case.