### PR TITLE
Add shader uniforms to shader through scripting

### DIFF
--- a/assets/shader_scripts/shader.lua
+++ b/assets/shader_scripts/shader.lua
@@ -1,4 +1,4 @@
 addStage("Vertex", "shaders/build/v_simple.bin")
 addStage("Fragment", "shaders/build/f_simple.bin")
 
-addUniform("v_k", "vec4")
+addUniform("Constant", "Vec4")

--- a/assets/shader_scripts/shader.lua
+++ b/assets/shader_scripts/shader.lua
@@ -1,2 +1,4 @@
 addStage("Vertex", "shaders/build/v_simple.bin")
 addStage("Fragment", "shaders/build/f_simple.bin")
+
+addUniform("v_k", "vec4", { 1.0, 1.0, 1.0, 1.0 })

--- a/assets/shader_scripts/shader.lua
+++ b/assets/shader_scripts/shader.lua
@@ -1,4 +1,4 @@
 addStage("Vertex", "shaders/build/v_simple.bin")
 addStage("Fragment", "shaders/build/f_simple.bin")
 
-addUniform("v_k", "vec4", { 1.0, 1.0, 1.0, 1.0 })
+addUniform("v_k", "vec4")

--- a/shaders/f_simple.sc
+++ b/shaders/f_simple.sc
@@ -2,9 +2,13 @@ $input v_texcoord0
 
 #include <bgfx_shader.sh>
 
+uniform vec4 u_params[1];
+
+#define u_k u_params[0].x
+
 SAMPLER2D(s_cubeTex, 0);
 
 void main()
 {
-    gl_FragColor = texture2D(s_cubeTex, v_texcoord0);
+    gl_FragColor = texture2D(s_cubeTex, v_texcoord0) * u_k;
 }

--- a/shaders/f_simple.sc
+++ b/shaders/f_simple.sc
@@ -2,9 +2,9 @@ $input v_texcoord0
 
 #include <bgfx_shader.sh>
 
-uniform vec4 u_params[1];
+uniform vec4 u_params[12];
 
-#define u_k u_params[0].x
+#define u_k u_params[1].w
 
 SAMPLER2D(s_cubeTex, 0);
 

--- a/source/gfx/render_pipeline.cpp
+++ b/source/gfx/render_pipeline.cpp
@@ -9,6 +9,8 @@
 #include <fstream>
 
 namespace gfx {
+    constexpr int MaxShaderParams = 16;
+
     bgfx::ShaderHandle loadShader(const char* _name) {
         char* data = new char[2048];
         std::ifstream file;
@@ -82,6 +84,7 @@ namespace gfx {
         void initialize() override {
             PosTextVertex::init();
 
+            mShaderParamsUniformHandle = bgfx::createUniform("u_params", bgfx::UniformType::Vec4, MaxShaderParams);
             mTexture = Texture2D::loadFromFile("assets/bricks.png");
             mTextureUniform = bgfx::createUniform("v_texCoord0", bgfx::UniformType::Sampler);
 
@@ -150,7 +153,9 @@ namespace gfx {
             mTexture->render(mTextureUniform);
             bgfx::setState(BGFX_STATE_DEFAULT);
 
-            // Submit primitive for rendering to view 0.
+            float params[8] = { 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
+            bgfx::setUniform(mShaderParamsUniformHandle, params, MaxShaderParams);
+
             mShader->bind(0);
 
             bgfx::frame();
@@ -164,6 +169,7 @@ namespace gfx {
         bgfx::FrameBufferHandle mFbh;
 
         bgfx::UniformHandle mTextureUniform = BGFX_INVALID_HANDLE;
+        bgfx::UniformHandle mShaderParamsUniformHandle = BGFX_INVALID_HANDLE;
 
         std::unique_ptr<Texture2D> mTexture { nullptr };
 

--- a/source/gfx/shader.cpp
+++ b/source/gfx/shader.cpp
@@ -24,15 +24,15 @@ namespace gfx {
         }
 
         mProgramHandle = bgfx::createProgram(mVertexShaderHandle, mFragmentShaderHandle, mDestroyShaders);
-        mParamsUniformHandle = bgfx::createUniform("u_params", bgfx::UniformType::Vec4);
+        mParamsUniformHandle = bgfx::createUniform("u_params", bgfx::UniformType::Vec4, 12);
 
         mCompiled = true;
     }
 
     void Shader::bind(uint16_t viewId) {
-        float params[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+        float params[8] = { 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
 
-        bgfx::setUniform(mParamsUniformHandle, params);
+        bgfx::setUniform(mParamsUniformHandle, params, 12);
 
         bgfx::submit(viewId, mProgramHandle);
     }

--- a/source/gfx/shader.cpp
+++ b/source/gfx/shader.cpp
@@ -3,6 +3,7 @@
 namespace gfx {
     Shader::~Shader() {
         if (compiled()) {
+            bgfx::destroy(mParamsUniformHandle);
             bgfx::destroy(mProgramHandle);
         }
     }
@@ -23,10 +24,20 @@ namespace gfx {
         }
 
         mProgramHandle = bgfx::createProgram(mVertexShaderHandle, mFragmentShaderHandle, mDestroyShaders);
+        mParamsUniformHandle = bgfx::createUniform("u_params", bgfx::UniformType::Vec4);
+
         mCompiled = true;
     }
 
     void Shader::bind(uint16_t viewId) {
+        float params[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+
+        bgfx::setUniform(mParamsUniformHandle, params);
+
         bgfx::submit(viewId, mProgramHandle);
+    }
+
+    void Shader::addUniform(const Uniform &uniform) {
+        mUniforms.push(uniform);
     }
 }

--- a/source/gfx/shader.cpp
+++ b/source/gfx/shader.cpp
@@ -8,7 +8,7 @@ namespace gfx {
     }
 
     void Shader::addStage(gfx::ShaderStage&& stage) {
-        mStages.push_back(std::move(stage));
+        mStages.push(std::move(stage));
     }
 
     void Shader::compile() {

--- a/source/gfx/shader.cpp
+++ b/source/gfx/shader.cpp
@@ -30,10 +30,6 @@ namespace gfx {
     }
 
     void Shader::bind(uint16_t viewId) {
-        float params[8] = { 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
-
-        bgfx::setUniform(mParamsUniformHandle, params, 12);
-
         bgfx::submit(viewId, mProgramHandle);
     }
 

--- a/source/gfx/shader.h
+++ b/source/gfx/shader.h
@@ -60,6 +60,10 @@ namespace gfx {
             return mCompiled;
         }
 
+        [[nodiscard]] constexpr ALWAYS_INLINE const Vector<Uniform>& uniforms() const {
+            return mUniforms;
+        }
+
         void addUniform(const Uniform &uniform);
     private:
         bgfx::ProgramHandle mProgramHandle = BGFX_INVALID_HANDLE;

--- a/source/gfx/shader.h
+++ b/source/gfx/shader.h
@@ -24,8 +24,20 @@ namespace gfx {
         Vector<char> data;
     };
 
+    struct Uniform {
+        std::string name;
+
+        bgfx::UniformHandle handle;
+        bgfx::UniformType::Enum type;
+    };
+
     class Shader {
     public:
+        explicit Shader(Allocator &allocator)
+            : mStages(allocator)
+            , mUniforms(allocator)
+        {}
+
         ~Shader();
 
         void addStage(gfx::ShaderStage&& stage);
@@ -45,9 +57,10 @@ namespace gfx {
         bgfx::ShaderHandle mVertexShaderHandle = BGFX_INVALID_HANDLE;
         bgfx::ShaderHandle mFragmentShaderHandle = BGFX_INVALID_HANDLE;
 
-        bool mCompiled;
+        bool mCompiled { false };
         bool mDestroyShaders { true };
 
-        std::vector<ShaderStage> mStages;
+        Vector<ShaderStage> mStages;
+        Vector<Uniform> mUniforms;
     };
 }

--- a/source/gfx/shader.h
+++ b/source/gfx/shader.h
@@ -28,7 +28,15 @@ namespace gfx {
 
     struct Uniform {
         std::string name;
-        bgfx::UniformType::Enum type;
+
+       enum class Type {
+            Float,
+            Vec2,
+            Vec3,
+            Vec4,
+            Mat3,
+            Mat4
+        } type;
     };
 
     class Shader {

--- a/source/gfx/shader.h
+++ b/source/gfx/shader.h
@@ -29,10 +29,6 @@ namespace gfx {
     struct Uniform {
         std::string name;
         bgfx::UniformType::Enum type;
-
-        union {
-            glm::vec4 v4;
-        } value;
     };
 
     class Shader {

--- a/source/gfx/shader.h
+++ b/source/gfx/shader.h
@@ -8,6 +8,8 @@
 
 #include "engine/vector.h"
 
+#include <glm/glm.hpp>
+
 namespace gfx {
     enum class ShaderType {
         Vertex,
@@ -26,9 +28,11 @@ namespace gfx {
 
     struct Uniform {
         std::string name;
-
-        bgfx::UniformHandle handle;
         bgfx::UniformType::Enum type;
+
+        union {
+            glm::vec4 v4;
+        } value;
     };
 
     class Shader {
@@ -51,6 +55,8 @@ namespace gfx {
         [[nodiscard]] constexpr ALWAYS_INLINE bool compiled() const {
             return mCompiled;
         }
+
+        void addUniform(const Uniform &uniform);
     private:
         bgfx::ProgramHandle mProgramHandle = BGFX_INVALID_HANDLE;
 
@@ -62,5 +68,7 @@ namespace gfx {
 
         Vector<ShaderStage> mStages;
         Vector<Uniform> mUniforms;
+
+        bgfx::UniformHandle mParamsUniformHandle = BGFX_INVALID_HANDLE;
     };
 }

--- a/source/gfx/shader_manager.cpp
+++ b/source/gfx/shader_manager.cpp
@@ -4,8 +4,8 @@
 #include "engine/engine.h"
 
 namespace gfx {
-    namespace lua_api {
-        static Shader* get_shader(lua_State *L) {
+    namespace luaApi {
+        static Shader* getShader(lua_State *L) {
             lua_getglobal(L, "this");
             auto shader = lua::convertType<Shader*>(L, -1);
             lua_pop(L, 1);
@@ -13,7 +13,7 @@ namespace gfx {
         }
 
         static int addStage(lua_State *L) {
-            auto shader = get_shader(L);
+            auto shader = getShader(L);
             auto shaderType = std::string { lua::checkArg<const char*>(L, 1) };
             auto path = std::string { lua::checkArg<const char*>(L, 2) };
 
@@ -47,15 +47,61 @@ namespace gfx {
             return 0;
         }
 
-        static lua_State* get_shader_state() {
+        static int addUniform(lua_State *L) {
+            auto shader = getShader(L);
+
+            auto uniformName = std::string{lua::checkArg<const char *>(L, 1)};
+            auto uniformType = std::string{lua::checkArg<const char *>(L, 2)};
+
+            Uniform uniform;
+            uniform.name = uniformName;
+
+            static std::unordered_map<std::string, bgfx::UniformType::Enum> uniformTypeMap{
+                    {"sampler", bgfx::UniformType::Sampler},
+                    {"vec4",    bgfx::UniformType::Vec4},
+                    {"mat3",    bgfx::UniformType::Mat3},
+                    {"mat4",    bgfx::UniformType::Mat4}
+            };
+
+            auto uniformTypeIt = uniformTypeMap.find(uniformType);
+            if (uniformTypeIt == uniformTypeMap.end()) {
+                throw std::runtime_error("Invalid uniform type");
+            }
+
+            uniform.type = uniformTypeIt->second;
+
+            if (lua_gettop(L) > 2) {
+                switch (lua_type(L, 3)) {
+                    case LUA_TTABLE: {
+                        auto len = luaL_len(L, 3);
+                        switch (len) {
+                            case 4:
+                                uniform.value.v4 = lua::checkArg<glm::vec4>(L, 3);
+                                break;
+                            default:
+                                luaL_error(L, "Uniform %s is not supported", uniformName.c_str());
+                                break;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            shader->addUniform(uniform);
+        }
+
+        static lua_State* getShaderState() {
             static lua_State* L { nullptr };
 
             if (L == nullptr) {
                 L = luaL_newstate();
                 luaL_openlibs(L);
 
-                lua_pushcfunction(L, lua_api::addStage);
+                lua_pushcfunction(L, luaApi::addStage);
                 lua_setglobal(L, "addStage");
+
+                lua_pushcfunction(L, luaApi::addUniform);
+                lua_setglobal(L, "addUniform");
             }
 
             return L;
@@ -68,14 +114,14 @@ namespace gfx {
         FileReader fileReader { path.value() };
         auto fileContent = fileReader.getFileContent();
 
-        auto root_state = lua_api::get_shader_state();
+        auto root_state = luaApi::getShaderState();
         auto L = lua_newthread(root_state);
         const auto state_ref = luaL_ref(root_state, LUA_REGISTRYINDEX);
 
         lua_pushlightuserdata(L, shader.get());
         lua_setglobal(L, "this");
 
-        lua::execute(lua_api::get_shader_state(), fileContent, path.value(), 0);
+        lua::execute(luaApi::getShaderState(), fileContent, path.value(), 0);
 
         luaL_unref(root_state, LUA_REGISTRYINDEX, state_ref);
 

--- a/source/gfx/shader_manager.cpp
+++ b/source/gfx/shader_manager.cpp
@@ -56,11 +56,13 @@ namespace gfx {
             Uniform uniform;
             uniform.name = uniformName;
 
-            static std::unordered_map<std::string, bgfx::UniformType::Enum> uniformTypeMap{
-                    {"sampler", bgfx::UniformType::Sampler},
-                    {"vec4",    bgfx::UniformType::Vec4},
-                    {"mat3",    bgfx::UniformType::Mat3},
-                    {"mat4",    bgfx::UniformType::Mat4}
+            static std::unordered_map<std::string, Uniform::Type> uniformTypeMap{
+                { "Float", Uniform::Type::Float },
+                { "Vec2", Uniform::Type::Vec2 },
+                { "Vec3", Uniform::Type::Vec3 },
+                { "Vec4", Uniform::Type::Vec4 },
+                { "Mat3", Uniform::Type::Mat3 },
+                { "Mat4", Uniform::Type::Mat4 }
             };
 
             auto uniformTypeIt = uniformTypeMap.find(uniformType);

--- a/source/gfx/shader_manager.cpp
+++ b/source/gfx/shader_manager.cpp
@@ -70,23 +70,6 @@ namespace gfx {
 
             uniform.type = uniformTypeIt->second;
 
-            if (lua_gettop(L) > 2) {
-                switch (lua_type(L, 3)) {
-                    case LUA_TTABLE: {
-                        auto len = luaL_len(L, 3);
-                        switch (len) {
-                            case 4:
-                                uniform.value.v4 = lua::checkArg<glm::vec4>(L, 3);
-                                break;
-                            default:
-                                luaL_error(L, "Uniform %s is not supported", uniformName.c_str());
-                                break;
-                        }
-                        break;
-                    }
-                }
-            }
-
             shader->addUniform(uniform);
         }
 

--- a/source/gfx/shader_manager.cpp
+++ b/source/gfx/shader_manager.cpp
@@ -63,7 +63,7 @@ namespace gfx {
     }
 
     Shader* ShaderManager::createShader(const Path &path) {
-        auto shader = std::make_unique<Shader>();
+        auto shader = std::make_unique<Shader>(Engine::instance().allocator());
 
         FileReader fileReader { path.value() };
         auto fileContent = fileReader.getFileContent();


### PR DESCRIPTION
It's now possible to add uniforms to shaders. This will be a step forward towards implementing the rendering system. Where materials of objects will contains properties that have to be filled in the uniform. We can later map those values to the uniform values int the shader and render them accordingly.